### PR TITLE
在 UI Control 界面添加 Html & Markdown 保存格式的选项

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ native-app/test/mx-wc/clippings
 native-app/test/mx-wc/global-assets
 useful-res/assistant/public/dev/*.js
 useful-res/assistant/public/dist/*.js
+
+.vscode

--- a/src/js/content/save.js
+++ b/src/js/content/save.js
@@ -3,9 +3,9 @@
 
 this.MxWcSave = (function (MxWcConfig, ExtApi) {
 
-  // inputs => {:title, :category, :tagstr, :elem}
+  // inputs => {:format, :title, :category, :tagstr, :elem}
   function save(inputs) {
-    let {title, category, tagstr, elem} = inputs;
+    let {format, title, category, tagstr, elem} = inputs;
     MxWcConfig.load().then((config) => {
       if(title.trim() === ""){
         title = 'default';
@@ -23,7 +23,7 @@ this.MxWcSave = (function (MxWcConfig, ExtApi) {
       if (config.saveTitleAsFilename) {
         name = T.sanitizeFilename(title);
       }
-      const filename = name + '.' + config.saveFormat;
+      const filename = name + '.' + format;
 
       // deal Fold
       const now = T.currentTime();
@@ -70,7 +70,7 @@ this.MxWcSave = (function (MxWcConfig, ExtApi) {
 
       const info = {
         clipId     : clipId,
-        format     : config.saveFormat,
+        format     : format,
         title      : title,
         link       : window.location.href,
         category   : category,
@@ -80,7 +80,7 @@ this.MxWcSave = (function (MxWcConfig, ExtApi) {
       }
 
       let parser = null;
-      switch(config.saveFormat){
+      switch(format){
         case 'html' : parser = MxWcHtml; break;
         case 'md'   : parser = MxWcMarkdown; break;
       }

--- a/src/js/template.js
+++ b/src/js/template.js
@@ -67,6 +67,13 @@ MxWcTemplate.UIHtml = {
 </div>
 <div class="${v.g} MX-wc-form">
   <div class="${v.g} MX-input-group">
+    <label class="${v.g}">${t('setting.title.save-format')}</label>
+    <div class="MX-options-group" id="${v.id.format}">
+      <a data-value="html">HTML</a>
+      <a data-value="md">Markdown</a>
+    </div>
+  </div>
+  <div class="${v.g} MX-input-group">
     <label class="${v.g}">${t('title')}</label>
     <input class="${v.g}" type="text" id="${v.id.title}"/>
   </div>

--- a/src/pages/ui-control.css
+++ b/src/pages/ui-control.css
@@ -142,6 +142,32 @@ body {
   display: none;
   color: #888;
 }
+
+.MX-options-group > a{
+  text-decoration: none;
+  display: inline-block;
+  margin-right: 10px;
+  border: solid 1px #ccc;
+  padding: 5px 5px 5px 5px;
+  min-width: 80px;
+  text-align: center;
+  line-height: 15px;
+  color: #9F9F9F;
+  cursor: pointer;
+}
+
+.MX-options-group > a:hover {
+  color: #333;
+  background-color: #F5F5F5;
+}
+
+.MX-options-group > a.active {
+  color: #333;
+  border: 2px dashed green;
+  font-weight: bold;
+  background-color: #E8E8E8;
+}
+
 .MX-input-group{
   margin-bottom: 15px;
   width: 100%;

--- a/src/pages/ui-control.js
+++ b/src/pages/ui-control.js
@@ -10,6 +10,7 @@
   const CLASS_HINT       = 'MX-wc-hint';
 
   const ID_TITLE         = "MX-wc-title";
+  const ID_FORMAT        = 'MX-wc-format';
   const ID_CATEGORY      = "MX-wc-category";
   const ID_TAGSTR        = "MX-wc-tagstr";
   const CLASS_FORM       = "MX-wc-form";
@@ -80,6 +81,7 @@
       g: CLASS_ENTRY,
       id: {
         btn      : ID_BTN,
+        format   : ID_FORMAT,
         category : ID_CATEGORY,
         tagstr   : ID_TAGSTR,
         title    : ID_TITLE,
@@ -283,16 +285,38 @@
     }
   }
 
-  function showForm(msg){
+  async function initSaveFormatOption(formatOption) {
+    const config = await MxWcConfig.load();
+    T.bind(formatOption, 'click', (e) => {
+      if(e.target.tagName === 'A'){
+        const value = e.target.getAttribute('data-value');
+        updateOptionsState(formatOption, value)
+      }
+    });
+    updateOptionsState(formatOption, config["saveFormat"]);
+
+    function updateOptionsState(elem, value) {
+      T.each(elem.children, (option) => {
+        option.classList.remove('active');
+        const optionValue = option.getAttribute('data-value');
+        if(optionValue === value){
+          option.classList.add('active');
+        }
+      });
+    }
+  }
+
+  async function showForm(msg){
     const form = T.firstElem(CLASS_FORM);
     if(form.style.display == 'block'){ return false}
     setStateConfirmed();
     form.style.display = 'block';
+    const formatBlock = T.findElem(ID_FORMAT);
     const titleInput = T.findElem(ID_TITLE);
     const categoryInput = T.findElem(ID_CATEGORY);
     const tagstrInput = T.findElem(ID_TAGSTR);
 
-
+    await initSaveFormatOption(formatBlock);
     titleInput.value = msg.title;
     categoryInput.value= msg.category;
     tagstrInput.value = msg.tagstr;
@@ -338,11 +362,13 @@
     hideForm();
     unbindListener();
 
+    const formatBlock = T.findElem(ID_FORMAT);
     const titleInput = T.findElem(ID_TITLE);
     const categoryInput = T.findElem(ID_CATEGORY);
     const tagstrInput = T.findElem(ID_TAGSTR);
 
     sendFrameMsgToTop('startClip', {
+      format: formatBlock.querySelector(".active").getAttribute('data-value'),
       title: titleInput.value,
       category: categoryInput.value,
       tagstr: tagstrInput.value,


### PR DESCRIPTION
某些网页适合保存成 Html 而另外一些适合保存成 Markdown ，为了避免在设置页面来回切换，我在剪裁保存时的 ui-control 上添加了一个 “保存格式” 的选项。