### PR TITLE
Fix needSaveIndexFile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vscode
 .ignore/
 node_modules/
+dist/extension/maoxian-web-clipper
 dist/extension/*.zip
 dist/extension/*.xpi
 dist/native-app/*.zip

--- a/src/js/content/input-parser-wiznoteplus.js
+++ b/src/js/content/input-parser-wiznoteplus.js
@@ -42,7 +42,6 @@
           /** the path to place index.html and assetFolder */
           mainFileFolder: clipId,
           mainFileName: mainFilename,
-          infoFileFolder: clipId + "/index_files",
           /** the path to place frame files */
           frameFileFolder: clipId + "/index_files",
           /** the path to place asset files */
@@ -67,6 +66,8 @@
           info: info,
           storageInfo: storageInfo,
           input: inputHistory,
+          /* We don't need to save index.json, so we don't need infoFileFolder
+             and infoFileName too. */
           needSaveIndexFile: false,
           needSaveTitleFile: false
       }

--- a/src/js/content/save.js
+++ b/src/js/content/save.js
@@ -71,9 +71,11 @@
       const _tasks = Task.rmReduplicate(tasks);
 
       // calculate path
-      info.paths = [storageInfo.infoFileName];
+      info.paths = [];
+      if (needSaveIndexFile)
+        info.paths.push(storageInfo.infoFileName);
       const {mainPath, paths} = Task.getRelativePath(
-        _tasks, storageInfo.infoFileFolder);
+        _tasks, storageInfo.mainFileFolder);
       info.mainPath = mainPath;
       info.paths.push(...paths);
 
@@ -95,7 +97,8 @@
         body: clipping
       });
 
-      saveClippingHistory(info, storageInfo);
+      if (needSaveIndexFile)
+        saveClippingHistory(info, storageInfo);
     })
 
   }

--- a/src/js/content/save.js
+++ b/src/js/content/save.js
@@ -64,22 +64,24 @@
 
     const params = { storageInfo: storageInfo, elem: elem, info: info, config: config }
     parser.parse(params).then((tasks) => {
+
       if(needSaveTitleFile) {
         const filename = T.joinPath(storageInfo.titleFileFolder, storageInfo.titleFileName);
         tasks.unshift(Task.createTitleTask(filename, info.clipId));
       }
       const _tasks = Task.rmReduplicate(tasks);
 
-      // calculate path
+      // info.paths is used to delete files.
       info.paths = [];
-      if (needSaveIndexFile)
-        info.paths.push(storageInfo.infoFileName);
-      const {mainPath, paths} = Task.getRelativePath(
-        _tasks, storageInfo.mainFileFolder);
-      info.mainPath = mainPath;
-      info.paths.push(...paths);
+      if (needSaveIndexFile) {
 
-      if(needSaveIndexFile) {
+        // calculate path
+        info.paths.push(storageInfo.infoFileName);
+        const {mainPath, paths} = Task.getRelativePath(
+          _tasks, storageInfo.infoFileFolder);
+        info.mainPath = mainPath;
+        info.paths.push(...paths);
+
         const filename = T.joinPath(storageInfo.infoFileFolder, storageInfo.infoFileName);
         _tasks.unshift(Task.createInfoTask(filename, info))
       }


### PR DESCRIPTION
最近我重新检查了一下上一次的 pull request，发现这个补丁没有将问题解决完全。通过查看剪裁页面 ContentScript 的控制台信息，可以发现相关的报错信息。

问题主要发生在这里 `save.js` 中：

```javascript
  function saveClippingHistory(info, storageInfo){
    const path = T.joinPath(storageInfo.infoFileFolder, storageInfo.infoFileName);
    const clippingHistory = Object.assign({path: path}, info);
    ExtMsg.sendToBackground({
      type: 'save.clippingHistory',
      body: {clippingHistory: clippingHistory}
    })
  }
```

因为 `input-parser-wiznoteplus` 不需要 `needSaveIndexFile` ，因此自然也不需要提供 `infoFileFolder` 和 `infoFileName` 。这就导致了 `storageInfo.infoFileName` 未定义，所以 `saveClippingHistory` 执行过程中会抛出异常。

这个 pull request 主要修改了 `save.js` 中的代码，使其根据 ``needSaveIndexFile` ` 做出不同的反应。

但是我不能确定的一点在这里：

```javascript
      // calculate path
      info.paths = [];
      if (needSaveIndexFile)
        info.paths.push(storageInfo.infoFileName);
      const {mainPath, paths} = Task.getRelativePath(
        _tasks, storageInfo.mainFileFolder);
      info.mainPath = mainPath;
      info.paths.push(...paths);
```

其中 `info.paths` 的用途我没用搞明白，不知道我将 `storageInfo.infoFileFolder` 改为 `storageInfo.mainFileFolder` 有没有额外的影响，不过默认设置里这两者相同的。

我使用 clipping-handler-wiznoteplus 测试过了，没有再抛出剪裁异常。但这个 pull request 需要 mika 你使用其他 handler 测试并确定一下是否有不期望的行为。