### PR TITLE
fix undefined info.mainPath

### DIFF
--- a/src/js/content/save.js
+++ b/src/js/content/save.js
@@ -85,11 +85,14 @@
         const filename = T.joinPath(storageInfo.infoFileFolder, storageInfo.infoFileName);
         _tasks.unshift(Task.createInfoTask(filename, info))
       } else {
-        let _filtered = _tasks.filter(it => it.taskType === 'mainFileTask')
-        if (_filtered.length != 1)
-          throw Error("Can not find unique mainFileTask");
-        let mainFileTask = _filtered[0];
-        info.mainPath = T.calcPath(storageInfo.mainFileFolder, mainFileTask.filename);
+        const mainFileTask = _tasks.find(it => it.taskType === 'mainFileTask')
+        if (mainFileTask) {
+          // We assume infoFileFolder is same as mainFileFolder.
+          const infoFileFolder = storageInfo.mainFileFolder;
+          info.mainPath = T.calcPath(infoFileFolder, mainFileTask.filename);
+        } else {
+          throw Error("Can not find mainFileTask");
+        }
       }
 
       const clipping = {

--- a/src/js/content/save.js
+++ b/src/js/content/save.js
@@ -84,6 +84,12 @@
 
         const filename = T.joinPath(storageInfo.infoFileFolder, storageInfo.infoFileName);
         _tasks.unshift(Task.createInfoTask(filename, info))
+      } else {
+        let _filtered = _tasks.filter(it => it.taskType === 'mainFileTask')
+        if (_filtered.length != 1)
+          throw Error("Can not find unique mainFileTask");
+        let mainFileTask = _filtered[0];
+        info.mainPath = T.calcPath(storageInfo.mainFileFolder, mainFileTask.filename);
       }
 
       const clipping = {


### PR DESCRIPTION
修复 `info.mainPath` 未定义的问题。

其实从这个问题以及前面几个 hotfix ，我看到了比较麻烦的一点。**MaoXian WebClipper 缺少足够的测试用例**。

我最近在为 MaoXian WebClipper 整理一份发展计划，里面涉及到使用 Webpack 将插件构建工程化、使用 npm 管理插件的依赖、以及编写覆盖率足够高的测试用例。不知道 mika 你是否有兴趣一起搞一搞？通过 Tutanota 邮件或者 Telegram 私聊都行？