### PR TITLE
Simple support for tiddlywiki

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ native-app/pack.yaml
 native-app/pack.yaml.production
 native-app/test/mx-wc/clippings
 native-app/test/mx-wc/global-assets
+.idea
+.DS_Store
+yarn.lock


### PR DESCRIPTION
希望作者能添加对tiddlywiki的支持，本来我是按照`NEW add zip clipping-handler`来做的，但是storage-config这块没有搞得很清楚，使用默认的storage-config在saveClipping阶段backend还会调用Browser的handle而不是新增的handle

其实只是实现了两个方法putTiddler和getInfo，其他的操作都和Browser相同
```js
function getInfo(callback) {
    Global.Fetcher.get(serverAddr + '/status', {timeout: 2, tries: 1}).then(
        (blob) => {
            callback({
                ready: true,
                supportFormats: ['md']
            });
        },
        (err) => {
            callback({
                ready: false,
                message: err.message,
                supportFormats: ['md']
            });
        }
    );
}
```

PS. tiddlywiki需要改造下路由，毕竟大量的图片嵌入html非常的没有必要，Browser抓取的本地图片才是最佳方案

node_modules/tiddlywiki/core/modules/server/server.js
```js
# Server.prototype.requestHandler下添加
    var inputPath = url.parse(request.url).pathname;
    var inputSplit = inputPath.lastIndexOf(".");
    if (inputSplit > 0 && inputPath.indexOf(":") < 0) {
        var fileSuffix = inputPath.substring(inputSplit + 1)
        if (fileSuffix == "jpg" || fileSuffix == "jpeg" || fileSuffix == "png" || fileSuffix == "gif" || fileSuffix == "bmp" || fileSuffix == "webp") {
            var imageFilePath = decodeURIComponent(inputPath.substr(1));
            try {
                fs.accessSync(imageFilePath, fs.constants.R_OK);
                response.writeHead(200, {"Content-Type": "image/"+fileSuffix});
                var imageStream = fs.createReadStream(imageFilePath);
                var responseData = [];
                if (imageStream) {
                    imageStream.on("data", function(chunk) {
                      responseData.push(chunk);
                    });
                    imageStream.on("end", function() {
                       var finalData = Buffer.concat(responseData);
                       response.write(finalData);
                       response.end();
                    });
                    return;
                }
            } catch (err) {
                $tw.utils.log("Local image: [" + imageFilePath + "] read failed, will use default router...");
            }
        }
    }
```