### PR TITLE
FIX $TIME-INTSEC was not rendered for WizNotePlus

### DIFF
--- a/src/js/clipping/storage-config-wiznoteplus.js
+++ b/src/js/clipping/storage-config-wiznoteplus.js
@@ -4,7 +4,7 @@
 //==========================================
 
 function get({config}) {
-  const saveFolder = "$TIME-INTSEC";
+  const saveFolder = Math.floor(Date.now()/1000).toString();
 
   const defaultConfig = {
     rootFolder: config.rootFolder,


### PR DESCRIPTION
首先 StorageConfig_WizNotePlus 需要使用 `clipId` 作为 `saveFolder` 的值，但是新版本将 saveFolder 改成了如下形式：

```javascript
const saveFolder = "$TIME-INTSEC";
```

但由于 StorageConfig_WizNotePlus 不依赖于 `clippingFolderName` ，所以 `$TIME-INTSEC` 没有被渲染，如下：

```javascript
  let clippingPath = "clippingFolderName-not-specified";
  if (config.clippingFolderName) {
    const clippingFolderName = VariableRender.exec(config.clippingFolderName,
      filenameValueHash, VariableRender.FilenameVariables);
    clippingPath = T.joinPath(categoryPath, clippingFolderName);

    pathValueHash['clippingPath'] = clippingPath;
    pathVariables.push('$CLIPPING-PATH');
  } else {
    // 3rd party don't need clippingPath
  }
```

这里提出了一个临时的补丁：

```C++
const saveFolder = Math.floor(Date.now()/1000).toString();
```

这个补丁的前提假设是 `Date.now()` 与计算 clipId 的时刻是一致的，因为这里 `saveFolder` 使用的是 “秒” 级单位，所以绝大部分时候两者是一致的。