### PR TITLE
fix: correct 'accured' to 'occurred' typo in user-facing error message (ui.js:55)

### DIFF
--- a/src/js/content/ui.js
+++ b/src/js/content/ui.js
@@ -52,7 +52,7 @@ function appendIframe(){
 function throwIframeError(error) {
   console.error("MXWC.UI: ", error);
   const message = [
-    "Unexpected error accured when loading MaoXian UI (frame) " + this.element.id,
+    "Unexpected error occurred when loading MaoXian UI (frame) " + this.element.id,
     error.message,
     error.stack,
     "Please force refresh current web page (Ctrl + F5) and try again. If it still not work, try restart your browser"


### PR DESCRIPTION
## Summary
Fixes typo in the browser extension's UI error handler where the user-facing error message said 'accured' instead of 'occurred'.

## Change
- `src/js/content/ui.js` line 55: `Unexpected error accured when loading MaoXian UI (frame)` → `Unexpected error occurred when loading MaoXian UI (frame)`

## Context
This error is displayed to users when the MaoXian web clipper UI fails to load in a browser frame. Fixing the typo improves the user experience.

## Testing
- Verified the fix by checking the file contains the corrected spelling
- Single surgical fix targeting only the user-visible typo

---
Contributor: Jah-yee